### PR TITLE
feat: mailerLite embedded code w/ centralized captcha

### DIFF
--- a/css/newsletter.css
+++ b/css/newsletter.css
@@ -1,0 +1,7 @@
+.ml-form-recaptcha {
+  display: flex;
+  justify-self: center;
+  align-items: center;
+  flex-direction: column;
+  margin-bottom: 0;
+}

--- a/css/normalize.css
+++ b/css/normalize.css
@@ -17,6 +17,7 @@ html {
  */
 body {
   margin: 0;
+  overflow-x: hidden;
 }
 /* HTML5 display definitions
    ========================================================================== */

--- a/index.html
+++ b/index.html
@@ -8,11 +8,22 @@
   <link href="css/normalize.css" rel="stylesheet" type="text/css">
   <link href="css/webflow.css" rel="stylesheet" type="text/css">
   <link href="css/wize-mice-lp.webflow.css" rel="stylesheet" type="text/css">
+  <link href="css/newsletter.css" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com" rel="preconnect">
   <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin="anonymous">
   <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
   <script type="text/javascript">WebFont.load({  google: {    families: ["Open Sans:300,300italic,400,400italic,600,600italic,700,700italic,800,800italic","Barlow:regular,500,600,700,800"]  }});</script>
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <!-- MailerLite Universal -->
+  <script>
+    (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
+      .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
+      n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
+      (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
+      ml('account', '1372984');
+      </script>
+  <!-- End MailerLite Universal -->
+  <script src="js/newsletter.js" type="text/javascript" defer></script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
@@ -321,7 +332,7 @@
   <section class="footer-subscribe">
     <div class="container-6">
       <div class="footer-form-two w-form">
-        <form id="wf-form-Footer-Form-Two" name="wf-form-Footer-Form-Two" data-name="Footer Form Two" method="get" class="footer-form-container-two" data-wf-page-id="67a3f214f6f419803c655301" data-wf-element-id="a85965e7-8967-b1f5-ebaa-2cc34bca68c5">
+        <!-- <form id="wf-form-Footer-Form-Two" name="wf-form-Footer-Form-Two" data-name="Footer Form Two" method="get" class="footer-form-container-two" data-wf-page-id="67a3f214f6f419803c655301" data-wf-element-id="a85965e7-8967-b1f5-ebaa-2cc34bca68c5">
           <div class="footer-form-title">Subscribe to our <strong class="bold-text-16">newsletter</strong><br><strong class="bold-text-15">Discover everything about us first hand!</strong></div>
           <div class="footer-form-block-two"><input class="footer-form-input w-input" maxlength="256" name="Footer-Email-Two" data-name="Footer Email Two" aria-label="Enter your email" placeholder="Enter your email" type="email" id="Footer-Email-Two" required=""><input type="submit" data-wait="Please wait..." class="button-primary-2 footer-form-button w-button" value="Subscribe Now"></div>
         </form>
@@ -330,7 +341,8 @@
         </div>
         <div class="w-form-fail">
           <div>Oops! Something went wrong while submitting the form.</div>
-        </div>
+        </div> -->
+        <div class="ml-embedded" data-form="mhmiBW"></div>
       </div>
       <div class="footer-wrapper-three">
         <div class="w-layout-blockcontainer container-7 w-container"><img src="images/rato-branco.svg" loading="lazy" alt="wize isotype" class="image-5">

--- a/js/newsletter.js
+++ b/js/newsletter.js
@@ -1,0 +1,30 @@
+(() => {
+  document.addEventListener('DOMContentLoaded', startMutationObserver);
+
+  function startMutationObserver(_) {
+    const targetNode = document.querySelector('[data-form="mhmiBW"]');
+    const config = { attributes: true, childList: true, subtree: true };
+    // console.log("mutation target", targetNode);
+    targetNode.setAttribute('style', 'margin: -1rem 0');
+
+    const callback = (mutationList, observer) => {
+      for (const mutation of mutationList) {
+        if (mutation.type === "childList") {
+          console.log(`The child node ${targetNode} just changed with new newsletter elements added.`);
+          adjustCaptchaToCenter();
+          observer.disconnect();
+        }
+      }
+    }; 
+    const observer = new MutationObserver(callback);
+    observer.observe(targetNode, config);  
+  }
+
+  function adjustCaptchaToCenter(_) {
+    const captcha = document.querySelector('.ml-form-recaptcha');
+    if (captcha) {
+      captcha.setAttribute('style', '');
+      captcha.setAttribute('style', 'margin: 0');
+    }
+  }
+})()

--- a/js/newsletter.js
+++ b/js/newsletter.js
@@ -10,14 +10,14 @@
     const callback = (mutationList, observer) => {
       for (const mutation of mutationList) {
         if (mutation.type === "childList") {
-          console.log(`The child node ${targetNode} just changed with new newsletter elements added.`);
+          // console.log('The child node', targetNode, 'just changed with new newsletter elements added.');
           adjustCaptchaToCenter();
           observer.disconnect();
         }
       }
     }; 
     const observer = new MutationObserver(callback);
-    observer.observe(targetNode, config);  
+    observer.observe(targetNode, config);
   }
 
   function adjustCaptchaToCenter(_) {


### PR DESCRIPTION
Adding 3rd party form from MailerLite. Unfortunately they don't allow us to customize enough on their side so I provided a simple js/css combination to overwrite some of their default styles. For now, it is being used only to force captcha dialog to be centralized and remove its additional margin-bottom, but we can reach the original style overwritten the form coming from them later (or even from post-loaded iframes like the captcha itself).

In this pull request I've also added "overflow-x: hidden" to the whole body, once it was showing horizontal scrollbar in my tests.