### PR TITLE
Redesign site into focused one-page waitlist landing

### DIFF
--- a/css/wize-mice-lp.webflow.css
+++ b/css/wize-mice-lp.webflow.css
@@ -2662,3 +2662,148 @@
 }
 
 
+
+.wizemice-body {
+  background: linear-gradient(180deg, #121212 0%, #1b1b1b 100%);
+  color: #f4f4f4;
+  font-family: Barlow, sans-serif;
+  margin: 0;
+}
+
+.wm-section {
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 6.5rem 1.5rem;
+  text-align: center;
+}
+
+.wm-hero {
+  min-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.wm-logo {
+  width: 200px;
+  margin-bottom: 1rem;
+}
+
+.wm-section h1,
+.wm-section h2 {
+  color: #f4f4f4;
+  margin: 0 0 1.25rem;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+
+.wm-section h1 {
+  font-size: clamp(2.1rem, 6vw, 4rem);
+  line-height: 1.05;
+}
+
+.wm-section h2 {
+  font-size: clamp(1.8rem, 4.5vw, 2.8rem);
+}
+
+.wm-section h3 {
+  margin: 0 0 .6rem;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.wm-section p {
+  color: #dfdfdf;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  margin: 0 auto 1.2rem;
+  max-width: 700px;
+}
+
+.wm-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.wm-card,
+.wm-faq-item {
+  border: 1px solid #2a2a2a;
+  background: #151515;
+  border-radius: 18px;
+  padding: 1.4rem;
+  text-align: left;
+}
+
+.wm-btn {
+  display: inline-block;
+  margin-top: .75rem;
+  padding: .95rem 1.5rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: #121212;
+  font-weight: 700;
+  background: linear-gradient(100deg, #f96fe9, #f57a3e 35%, #fa494c 60%, #31d0f3 80%, #20e9b5 100%);
+  transition: filter .25s ease, box-shadow .25s ease;
+}
+
+.wm-btn:hover {
+  filter: brightness(1.08);
+  box-shadow: 0 0 22px #f96fe966;
+}
+
+.wm-faq {
+  text-align: left;
+}
+
+.wm-faq h2 {
+  text-align: center;
+}
+
+.wm-faq-item {
+  margin-bottom: 1rem;
+}
+
+.wm-faq-item p {
+  max-width: none;
+  margin-bottom: 0;
+}
+
+.wm-cta {
+  padding-top: 7.5rem;
+}
+
+.wm-cta .ml-embedded {
+  margin-top: 2.2rem;
+}
+
+.wm-footer {
+  border-top: 1px solid #2a2a2a;
+  padding: 2rem 1.5rem 3rem;
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.wm-footer a {
+  color: #dfdfdf;
+  text-decoration: none;
+}
+
+.wm-footer a:hover {
+  color: #f4f4f4;
+}
+
+@media screen and (max-width: 767px) {
+  .wm-section {
+    padding: 5rem 1.2rem;
+  }
+
+  .wm-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html><!--  This site was created in Webflow. https://webflow.com  --><!--  Last Published: Thu Mar 06 2025 18:29:57 GMT+0000 (Coordinated Universal Time)  -->
+<!DOCTYPE html>
 <html data-wf-page="67a3f214f6f419803c655301" data-wf-site="67a3f214f6f419803c6552fa">
 <head>
   <meta charset="utf-8">
@@ -12,353 +12,82 @@
   <link href="https://fonts.googleapis.com" rel="preconnect">
   <link href="https://fonts.gstatic.com" rel="preconnect" crossorigin="anonymous">
   <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
-  <script type="text/javascript">WebFont.load({  google: {    families: ["Open Sans:300,300italic,400,400italic,600,600italic,700,700italic,800,800italic","Barlow:regular,500,600,700,800"]  }});</script>
+  <script type="text/javascript">WebFont.load({ google: { families: ["Barlow:regular,500,600,700,800"] }});</script>
   <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
-  <!-- MailerLite Universal -->
   <script>
-    (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
-      .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
-      n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
-      (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
-      ml('account', '1372984');
-      </script>
-  <!-- End MailerLite Universal -->
+    (function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[]).push(arguments);},l=d.createElement(e),l.async=1,l.src=u,n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})(window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
+    ml('account', '1372984');
+  </script>
   <script src="js/newsletter.js" type="text/javascript" defer></script>
   <link href="images/favicon.png" rel="shortcut icon" type="image/x-icon">
   <link href="images/webclip.png" rel="apple-touch-icon">
 </head>
-<body class="body">
-  <section class="section-7">
-    <div class="w-layout-blockcontainer container-12 w-container"><img src="images/WizeMice-white.svg" loading="lazy" alt="wizemice logo" class="image-23"></div>
+<body class="wizemice-body">
+  <header class="wm-section wm-hero">
+    <img src="images/WizeMice-white.svg" loading="lazy" alt="WizeMice" class="wm-logo">
+    <h1>Not just a pedal.<br>An open platform for audio effects</h1>
+    <a href="#waitlist" class="wm-btn">Join the waitlist</a>
+  </header>
+
+  <section class="wm-section">
+    <h2>FREE THE SOUND!</h2>
+    <p>It’s a multi-effects pedal.<br>But instead of being locked to what’s inside, you can expand it.</p>
+    <p>Run plugins.<br>Build your own setup.</p>
+    <p>Think of it like a computer for your sound.<br>Built for the stage.</p>
   </section>
-  <div class="div-block-10">
-    <header data-poster-url="videos/spedwize-poster-00001.jpg" data-video-urls="videos/spedwize-transcode.mp4,videos/spedwize-transcode.webm" data-autoplay="true" data-loop="true" data-wf-ignore="true" class="background-video-3 w-background-video w-background-video-atom"><video id="9fa452f6-fee8-2d85-da35-9dc3200f7287-video" autoplay="" loop="" style="background-image:url(&quot;videos/spedwize-poster-00001.jpg&quot;)" muted="" playsinline="" data-wf-ignore="true" data-object-fit="cover">
-        <source src="videos/spedwize-transcode.mp4" data-wf-ignore="true">
-        <source src="videos/spedwize-transcode.webm" data-wf-ignore="true">
-      </video></header>
-  </div>
-  <section class="hero-heading-left">
-    <div class="container"></div>
-    <div class="div-block-2">
-      <h1 class="heading">Digitally<strong class="bold-text-7"> compact,<br>‍</strong>analogically<strong class="bold-text-8"> real.</strong></h1>
-      <p class="margin-bottom-24px">WizeMice provides the functionality of a full pedalboard.<br>But it&#x27;s way more than that...</p>
-      <div class="div-block-4">
-        <a href="#" class="uui-button w-inline-block">
-          <div class="text-block-6">Pre-sale Coming Soon</div>
-        </a>
-      </div>
-    </div>
-  </section>
-  <section class="uui-section_layout04">
-    <div class="w-layout-blockcontainer container-11 w-container"></div>
-    <div class="div-block-5">
-      <div class="uui-container-large">
-        <div class="uui-padding-vertical-xhuge">
-          <div class="w-layout-grid uui-layout04_component">
-            <div id="w-node-_85a15eb5-d3f4-2cd5-f414-f331af428e76-3c655301" class="uui-layout04_image-wrapper"><img src="images/multi4-min.png" loading="lazy" data-w-id="4410d6cc-e656-48a1-8151-65b1144d8da7" sizes="(max-width: 479px) 100vw, (max-width: 767px) 92vw, (max-width: 991px) 90vw, (max-width: 1439px) 46vw, 607.953125px" alt="guit" srcset="images/multi4-min-p-500.png 500w, images/multi4-min-p-800.png 800w, images/multi4-min-p-1080.png 1080w, images/multi4-min.png 1181w" class="image-12"><img src="images/multi2-min.png" loading="lazy" data-w-id="a4fc034b-ee33-1129-be91-7ee3b750a823" sizes="(max-width: 479px) 100vw, (max-width: 767px) 92vw, (max-width: 991px) 90vw, (max-width: 1439px) 46vw, 607.953125px" alt="keyb" srcset="images/multi2-min-p-500.png 500w, images/multi2-min-p-800.png 800w, images/multi2-min-p-1080.png 1080w, images/multi2-min.png 1181w" class="image-11">
-              <div class="div-block-8-copy">
-                <h2 class="uui-heading-medium"><strong class="bold-text-19">All-in-one</strong> Solution</h2>
-                <div class="uui-text-size-large">WizeMice supports <strong class="bold-text-22">guitar, bass, MIDI instruments, and vocals</strong>, adapting to any setup. With diverse inputs and tailored presets, it’s a perfect tool for multi-instrumentalists.</div>
-              </div><img src="images/multi1-min.png" loading="lazy" data-w-id="26636001-0bcd-a5d5-5600-c1b05cacf1cc" sizes="(max-width: 479px) 100vw, (max-width: 767px) 92vw, (max-width: 991px) 90vw, (max-width: 1439px) 46vw, 607.953125px" alt="mic" srcset="images/multi1-min-p-500.png 500w, images/multi1-min-p-800.png 800w, images/multi1-min-p-1080.png 1080w, images/multi1-min.png 1181w" class="image-13"><img src="images/multi3-min.png" loading="lazy" data-w-id="248faab4-3e0e-765c-47bd-0d124e451b33" sizes="(max-width: 479px) 100vw, (max-width: 767px) 92vw, (max-width: 991px) 90vw, (max-width: 1439px) 46vw, 607.953125px" alt="bass" srcset="images/multi3-min-p-500.png 500w, images/multi3-min-p-800.png 800w, images/multi3-min-p-1080.png 1080w, images/multi3-min.png 1181w" class="image-14">
-            </div>
-            <div class="div-block-8">
-              <h2 data-w-id="85a15eb5-d3f4-2cd5-f414-f331af428e55" style="opacity:0" class="uui-heading-medium">Built for Any<strong class="bold-text-19"> Instrument</strong></h2>
-              <div data-w-id="85a15eb5-d3f4-2cd5-f414-f331af428e58" style="opacity:0" class="uui-text-size-large">WizeMice is designed for <strong class="bold-text-22">guitar, bass, MIDI instruments, vocals and more</strong>, adapting to any setup. With different inputs and tailored presets, it’s a perfect tool for multi-instrumentalists.</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <section class="section-5"></section>
-    <div class="div-block-7">
-      <div class="uui-container-large">
-        <div class="uui-padding-vertical-xhuge">
-          <div class="w-layout-grid uui-layout04_component">
-            <div class="uui-layout04_content">
-              <h2 data-w-id="579de800-72ca-d50c-c0ae-2071340da3df" style="opacity:0" class="uui-heading-medium">Powerful &amp; Intuitive <strong class="bold-text-17">Software</strong></h2><img src="images/FX-chain-art.png" loading="lazy" sizes="(max-width: 479px) 93vw, (max-width: 767px) 96vw, (max-width: 991px) 97vw, 100vw" srcset="images/FX-chain-art-p-500.png 500w, images/FX-chain-art-p-800.png 800w, images/FX-chain-art-p-1080.png 1080w, images/FX-chain-art.png 1091w" alt="wize chain" class="image-16">
-              <div class="uui-space-xsmall"></div>
-              <div data-w-id="579de800-72ca-d50c-c0ae-2071340da3e4" style="opacity:0" class="uui-text-size-large">WizeMice software delivers a blend of user-friendly design and advanced functionality. Its intuitive touchscreen interface streamlines effect navigation and customization, enabling effortless sound creation.<br><br>In addition to its full standalone functionality, <strong class="bold-text-20">the device pairs with a desktop &amp; mobile app</strong> to provide expanded control and seamless integration.</div>
-              <div class="uui-button-row is-reverse-mobile-landscape-copy">
-                <div class="uui-button-wrapper max-width-full-mobile-landscape">
-                  <a href="#" class="uui-button w-inline-block">
-                    <div class="text-block-6">Pre-sale  Coming Soon</div>
-                  </a>
-                </div>
-              </div>
-            </div>
-            <div class="uui-layout04_image-wrapper-copy">
-              <div><img src="images/chain-fx-screen.png" loading="lazy" data-w-id="579de800-72ca-d50c-c0ae-2071340da3ef" sizes="(max-width: 991px) 100vw, (max-width: 1439px) 46vw, 608px" alt="chain fx screen " srcset="images/chain-fx-screen-p-500.png 500w, images/chain-fx-screen-p-800.png 800w, images/chain-fx-screen.png 1000w" class="image-17-copy"><img src="images/chain-fx.png" loading="lazy" sizes="(max-width: 991px) 100vw, (max-width: 1439px) 46vw, 608px" srcset="images/chain-fx-p-500.png 500w, images/chain-fx.png 800w" alt="chain fx" class="image-17"></div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="uui-page-padding">
-      <div class="uui-container-large">
-        <div class="uui-padding-vertical-xhuge">
-          <div class="w-layout-grid uui-layout04_component">
-            <div class="uui-layout04_image-wrapper"><img src="images/pedal-n-fxcard.png" loading="lazy" sizes="(max-width: 479px) 93vw, (max-width: 767px) 92vw, (max-width: 991px) 90vw, (max-width: 1439px) 46vw, 607.984375px" srcset="images/pedal-n-fxcard-p-500.png 500w, images/pedal-n-fxcard-p-800.png 800w, images/pedal-n-fxcard-p-1080.png 1080w, images/pedal-n-fxcard.png 1289w" alt="pedal n fx card" class="image-18"></div>
-            <div class="uui-layout04_content">
-              <h2 data-w-id="ed91105e-0934-9458-47a6-0db59b5126e2" style="opacity:0" class="uui-heading-medium"><strong class="bold-text-18">Analog</strong> Effect Card</h2>
-              <div class="uui-space-xsmall"></div>
-              <div data-w-id="ed91105e-0934-9458-47a6-0db59b5126e7" style="opacity:0" class="uui-text-size-large">Some tones like analog preamps, overdrives, distortion, vintage fuzz are irreplaceable.<br><br>While WizeMice offers high-quality digital effects, it also features <strong class="bold-text-21">hybrid functionality through Analog FX Cards</strong> that can have it’s parameters and presets controlled by our pedal via touchscreen and MIDI.</div>
-            </div>
-          </div>
-        </div>
-      </div>
+
+  <section class="wm-section">
+    <h2>FEATURES</h2>
+    <div class="wm-grid">
+      <div class="wm-card"><h3>Open for third-party effects</h3><p>Download plugins from our store or anywhere online</p></div>
+      <div class="wm-card"><h3>Built for any instrument</h3><p>Guitar, bass, synths, vocals, MIDI</p></div>
+      <div class="wm-card"><h3>High processing power</h3><p>Run powerful plugins with ease</p></div>
+      <div class="wm-card"><h3>Touchscreen control</h3><p>Shape your tone in a simple interface</p></div>
     </div>
   </section>
-  <div class="div-block-11">
-    <div data-current="Tab 2" data-easing="ease-in-out" data-duration-in="50" data-duration-out="50" class="tabs w-tabs">
-      <div class="tabs-menu w-tab-menu">
-        <a data-w-tab="Tab 1" class="tab-link-tab-1 w-inline-block w-tab-link"><img sizes="(max-width: 479px) 30vw, (max-width: 1439px) 20vw, 256px" srcset="images/Frame-506-p-500.png 500w, images/Frame-506-p-800.png 800w, images/Frame-506-p-1080.png 1080w, images/wizetiny.png 1280w" alt="wizetiny" src="images/wizetiny.png" loading="lazy" class="image-19">
-          <h1 class="heading-4"><strong>Wize</strong>Tiny</h1>
-        </a>
-        <a data-w-tab="Tab 2" class="tab-link-tab-2 w-inline-block w-tab-link w--current"><img sizes="(max-width: 479px) 30vw, (max-width: 991px) 19vw, (max-width: 1439px) 20vw, 250px" srcset="images/Frame-505-p-500.png 500w, images/Frame-505-p-800.png 800w, images/Frame-505-p-1080.png 1080w, images/wizecore.png 1280w" alt="wizecore front" src="images/wizecore.png" loading="lazy" class="image-20">
-          <h1 class="heading-4"><strong>Wize</strong>Core</h1>
-        </a>
-        <a data-w-tab="Tab 3" class="tab-link-tab-3 w-inline-block w-tab-link"><img sizes="(max-width: 479px) 30vw, (max-width: 1439px) 20vw, 255.984375px" srcset="images/Frame-504-p-500.png 500w, images/Frame-504-p-800.png 800w, images/Frame-504-p-1080.png 1080w, images/wizehub.png 1280w" alt="wize-hub front
-" src="images/wizehub.png" loading="lazy" class="image-20">
-          <h1 class="heading-4"><strong>Wize</strong>Hub</h1>
-        </a>
-      </div>
-      <div class="tabs-content w-tab-content">
-        <div data-w-tab="Tab 1" class="container-9 w-tab-pane">
-          <div data-current="Tab 1" data-easing="ease" data-duration-in="300" data-duration-out="100" class="w-tabs">
-            <div class="tabs-menu-2 w-tab-menu">
-              <a data-w-tab="Tab 1" class="tab-link-tab-1-2 w-inline-block w-tab-link w--current">
-                <div class="text-block-8">Front-view</div>
-              </a>
-              <a data-w-tab="Tab 2" class="tab-link-tab-2-2 w-inline-block w-tab-link">
-                <div class="text-block-9">Back-view</div>
-              </a>
-            </div>
-            <div class="w-tab-content">
-              <div data-w-tab="Tab 1" class="w-tab-pane w--tab-active"><img sizes="(max-width: 479px) 96vw, (max-width: 767px) 72vw, (max-width: 991px) 74vw, (max-width: 1439px) 75vw, 940px" srcset="images/Frame-506-p-500.png 500w, images/Frame-506-p-800.png 800w, images/Frame-506-p-1080.png 1080w, images/wizetiny.png 1280w" alt="wizetiny" src="images/wizetiny.png" loading="lazy"></div>
-              <div data-w-tab="Tab 2" class="w-tab-pane"><img sizes="(max-width: 479px) 96vw, (max-width: 767px) 72vw, (max-width: 991px) 74vw, (max-width: 1439px) 75vw, 940px" srcset="images/Frame-524-p-500.png 500w, images/Frame-524-p-800.png 800w, images/Frame-524.png 1280w" alt="WizeTiny Back" src="images/Frame-524.png" loading="lazy"></div>
-            </div>
-          </div>
-          <h1 class="heading-5"><strong>Wize</strong>Tiny<strong class="bold-text-23">®</strong></h1>
-          <div id="w-node-_4ca6f301-3e2c-01a0-2370-25b1f357f68f-3c655301" class="w-layout-layout quick-stack-3-copy wf-layout-layout">
-            <div class="w-layout-cell cell-5">
-              <div class="text-block-7">4x4&quot; Touchscreen</div>
-            </div>
-            <div class="w-layout-cell cell-5">
-              <div class="text-block-7">2x 1/4&quot; Output</div>
-            </div>
-          </div>
-          <div id="w-node-_5a97cd8b-ba28-5757-30b4-b81c45d231b1-3c655301" class="w-layout-layout quick-stack-4 wf-layout-layout">
-            <div class="w-layout-cell cell-5">
-              <div class="text-block-7">1x 1/4&quot; Input</div>
-            </div>
-            <div class="w-layout-cell cell-5">
-              <div class="text-block-7">1x MIDI USB Input</div>
-            </div>
-            <div class="w-layout-cell cell-5">
-              <div class="text-block-7">2x 1/4&quot; Output</div>
-            </div>
-            <div class="w-layout-cell cell-5">
-              <div class="text-block-7">4x4&quot; Touchscreen</div>
-            </div>
-          </div>
-        </div>
-        <div data-w-tab="Tab 2" class="w-tab-pane w--tab-active">
-          <div class="w-layout-blockcontainer container-9 w-container">
-            <div data-current="Tab 1" data-easing="ease" data-duration-in="300" data-duration-out="100" class="w-tabs">
-              <div class="tabs-menu-2 w-tab-menu">
-                <a data-w-tab="Tab 1" class="tab-link-tab-1-2 w-inline-block w-tab-link w--current">
-                  <div class="text-block-8">Front-view</div>
-                </a>
-                <a data-w-tab="Tab 2" class="tab-link-tab-2-2 w-inline-block w-tab-link">
-                  <div class="text-block-9">Back-view</div>
-                </a>
-              </div>
-              <div class="w-tab-content">
-                <div data-w-tab="Tab 1" class="w-tab-pane w--tab-active"><img sizes="(max-width: 479px) 96vw, (max-width: 767px) 72vw, (max-width: 991px) 74vw, (max-width: 1439px) 75vw, 940px" srcset="images/Frame-505-p-500.png 500w, images/Frame-505-p-800.png 800w, images/Frame-505-p-1080.png 1080w, images/wizecore.png 1280w" alt="wizecore front" src="images/wizecore.png" loading="lazy" class="image-22"></div>
-                <div data-w-tab="Tab 2" class="w-tab-pane"><img sizes="(max-width: 479px) 96vw, (max-width: 767px) 72vw, (max-width: 991px) 74vw, (max-width: 1439px) 75vw, 940px" srcset="images/Frame-523-p-500.png 500w, images/Frame-523-p-800.png 800w, images/Frame-523.png 1280w" alt="wizecore back" src="images/Frame-523.png" loading="lazy"></div>
-              </div>
-            </div>
-            <h1 class="heading-5"><strong>Wize</strong>Core<strong class="bold-text-23">®</strong></h1>
-            <div id="w-node-_07aa5871-6831-00c9-e9bf-f76fc7f41236-3c655301" class="w-layout-layout quick-stack-3 wf-layout-layout">
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">5x5&quot; Touchscreen</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">2x 1/4&quot; Output</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">Analog FX Card</div>
-              </div>
-            </div>
-            <div id="w-node-_07aa5871-6831-00c9-e9bf-f76fc7f4123d-3c655301" class="w-layout-layout quick-stack-4 wf-layout-layout">
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">2x 1/4&quot; Input</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">1x XLR Input</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">1x MIDI USB Input</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">1x MIDI DIN Input</div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div data-w-tab="Tab 3" class="w-tab-pane">
-          <div class="w-layout-blockcontainer container-9 w-container">
-            <div data-current="Tab 1" data-easing="ease" data-duration-in="300" data-duration-out="100" class="w-tabs">
-              <div class="tabs-menu-2 w-tab-menu">
-                <a data-w-tab="Tab 1" class="tab-link-tab-1-2 w-inline-block w-tab-link w--current">
-                  <div class="text-block-8">Front-view</div>
-                </a>
-                <a data-w-tab="Tab 2" class="tab-link-tab-2-2 w-inline-block w-tab-link">
-                  <div class="text-block-9">Back-view</div>
-                </a>
-              </div>
-              <div class="w-tab-content">
-                <div data-w-tab="Tab 1" class="w-tab-pane w--tab-active"><img sizes="(max-width: 479px) 96vw, (max-width: 767px) 72vw, (max-width: 991px) 74vw, (max-width: 1439px) 75vw, 940px" srcset="images/Frame-504-p-500.png 500w, images/Frame-504-p-800.png 800w, images/Frame-504-p-1080.png 1080w, images/wizehub.png 1280w" alt="wize-hub front
-" src="images/wizehub.png" loading="lazy"></div>
-                <div data-w-tab="Tab 2" class="w-tab-pane"><img sizes="(max-width: 479px) 96vw, (max-width: 767px) 72vw, (max-width: 991px) 74vw, (max-width: 1439px) 75vw, 940px" srcset="images/Frame-522-p-500.png 500w, images/Frame-522-p-800.png 800w, images/Frame-522.png 1280w" alt="wizehub back" src="images/Frame-522.png" loading="lazy"></div>
-              </div>
-            </div>
-            <h1 class="heading-5"><strong>Wize</strong>Hub<strong class="bold-text-23">®</strong></h1>
-            <div id="w-node-_52ec58a2-e97c-9ff0-acbb-577c430ea2d7-3c655301" class="w-layout-layout quick-stack-3 wf-layout-layout">
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">4x2&quot; Touchscreen</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">4x 1/4&quot; Output</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">5x Send/Return</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">2 Analog FX Card</div>
-              </div>
-            </div>
-            <div id="w-node-_52ec58a2-e97c-9ff0-acbb-577c430ea2de-3c655301" class="w-layout-layout quick-stack-4 wf-layout-layout">
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">4x 1/4&quot; Input</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">2x XLR Input</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">1x MIDI USB Input</div>
-              </div>
-              <div class="w-layout-cell cell-5">
-                <div class="text-block-7">1x MIDI DIN Input</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="uui-button-row is-reverse-mobile-landscape">
-      <div class="uui-button-wrapper max-width-full-mobile-landscape">
-        <a href="#" class="uui-button w-inline-block">
-          <div class="text-block-6">Pre-sale Coming Soon</div>
-        </a>
-      </div>
-    </div>
-  </div>
-  <section class="team-slider-2">
-    <div class="container-6">
-      <h2 data-w-id="29fb8a50-d316-544b-ffa6-6ee43fb72893" style="opacity:0" class="centered-heading-4">The <strong class="bold-text-12">Team</strong></h2>
-      <p data-w-id="29fb8a50-d316-544b-ffa6-6ee43fb72895" style="opacity:0" class="centered-subheading-4">WizeMice is more than just a company; <strong class="bold-text-13">we&#x27;re a band of dreamers, tech rats, and music lovers. </strong>We all share two passions: a deep love for music and a fascination with the evolving world of technology.</p>
-      <div data-delay="4000" data-animation="slide" class="team-slider-wrapper-2 w-slider" data-autoplay="true" data-easing="ease" data-hide-arrows="false" data-disable-swipe="false" data-autoplay-limit="0" data-nav-spacing="12" data-duration="500" data-infinite="true">
-        <div class="w-slider-mask">
-          <div class="team-slide-wrapper-2 w-slide">
-            <div class="team-block-2"><img src="images/suit-rat.png" loading="lazy" alt="suit rat" class="team-member-image-two-2">
-              <div class="team-block-info-2">
-                <h3 class="team-member-name-two-2">Matias Redard</h3>
-                <p class="team-member-text-2">Industrial Engineer<br>Guitar Player &amp; Producer</p>
-              </div>
-            </div>
-          </div>
-          <div class="team-slide-wrapper-2 w-slide">
-            <div class="team-block-2"><img src="images/electric-mage.png" loading="lazy" alt="" class="team-member-image-two-2">
-              <div class="team-block-info-2">
-                <h3 class="team-member-name-two-2">Pedro Nonino</h3>
-                <p class="team-member-text-2">Sound Software Sorcerer<br>Multi-Instrumentalist</p>
-              </div>
-            </div>
-          </div>
-          <div class="team-slide-wrapper-2 w-slide">
-            <div class="team-block-2"><img src="images/acid-rat.png" loading="lazy" alt="acid rat" class="team-member-image-two-2">
-              <div class="team-block-info-2">
-                <h3 class="team-member-name-two-2">Lucas Klepa</h3>
-                <p class="team-member-text-2">Design Maestro<br>Bass Player &amp; Singer</p>
-              </div>
-            </div>
-          </div>
-          <div class="team-slide-wrapper-2 w-slide">
-            <div class="team-block-2"><img src="images/hackerat.png" loading="lazy" alt="hackerrat" class="team-member-image-two-2">
-              <div class="team-block-info-2">
-                <h3 class="team-member-name-two-2">João Gabriel</h3>
-                <p class="team-member-text-2">Linux &amp; Full Stack Hacker<br>Guitar Player</p>
-              </div>
-            </div>
-          </div>
-          <div class="team-slide-wrapper-2 w-slide">
-            <div class="team-block-2"><img src="images/weldrat.png" loading="lazy" alt="weld rat" class="team-member-image-two-2">
-              <div class="team-block-info-2">
-                <h3 class="team-member-name-two-2">Arthur Hiroyuki</h3>
-                <p class="team-member-text-2">Electronic Engineer Tinkerer<br>Guitar Player</p>
-              </div>
-            </div>
-          </div>
-          <div class="team-slide-wrapper-2 w-slide">
-            <div class="team-block-2"><img src="images/board-rat.png" loading="lazy" data-w-id="29fb8a50-d316-544b-ffa6-6ee43fb728d7" alt="board rat" class="team-member-image-two-2">
-              <div class="team-block-info-2">
-                <h3 class="team-member-name-two-2">Filipe Alberti</h3>
-                <p class="team-member-text-2">Sound FX Guru<br>Guitar Player</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="team-slider-arrow-2 w-slider-arrow-left">
-          <div class="w-icon-slider-left"></div>
-        </div>
-        <div class="team-slider-arrow-2 w-slider-arrow-right">
-          <div class="w-icon-slider-right"></div>
-        </div>
-        <div class="team-slider-nav-2 w-slider-nav w-round"></div>
-      </div>
+
+  <section class="wm-section">
+    <h2>TONE3000</h2>
+    <p>Thousands of amps and pedals.<br>One place.</p>
+    <p>Tone3000 is the largest community for sharing NAM models</p>
+    <h3>What are NAMs?</h3>
+    <p>Ultra-realistic captures of real amps and pedals.</p>
+    <p>It’s like carrying real gear.<br>Without carrying real gear.</p>
+    <a href="#waitlist" class="wm-btn">Join the waitlist</a>
+  </section>
+
+  <section class="wm-section">
+    <h2>HARDWARE</h2>
+    <div class="wm-grid">
+      <div class="wm-card"><h3>Input / Output</h3><p>Stereo I/O, MIDI, USB-C, XLR</p></div>
+      <div class="wm-card"><h3>Processing</h3><p>Powered by Raspberry Pi CM5</p></div>
+      <div class="wm-card"><h3>Connectivity</h3><p>WiFi and Bluetooth</p></div>
+      <div class="wm-card"><h3>Expandable</h3><p>Analog FX cards for real analog tone</p></div>
     </div>
   </section>
-  <section class="footer-subscribe">
-    <div class="container-6">
-      <div class="footer-form-two w-form">
-        <!-- <form id="wf-form-Footer-Form-Two" name="wf-form-Footer-Form-Two" data-name="Footer Form Two" method="get" class="footer-form-container-two" data-wf-page-id="67a3f214f6f419803c655301" data-wf-element-id="a85965e7-8967-b1f5-ebaa-2cc34bca68c5">
-          <div class="footer-form-title">Subscribe to our <strong class="bold-text-16">newsletter</strong><br><strong class="bold-text-15">Discover everything about us first hand!</strong></div>
-          <div class="footer-form-block-two"><input class="footer-form-input w-input" maxlength="256" name="Footer-Email-Two" data-name="Footer Email Two" aria-label="Enter your email" placeholder="Enter your email" type="email" id="Footer-Email-Two" required=""><input type="submit" data-wait="Please wait..." class="button-primary-2 footer-form-button w-button" value="Subscribe Now"></div>
-        </form>
-        <div class="w-form-done">
-          <div>Thank you! Your submission has been received!</div>
-        </div>
-        <div class="w-form-fail">
-          <div>Oops! Something went wrong while submitting the form.</div>
-        </div> -->
-        <div class="ml-embedded" data-form="mhmiBW"></div>
-      </div>
-      <div class="footer-wrapper-three">
-        <div class="w-layout-blockcontainer container-7 w-container"><img src="images/rato-branco.svg" loading="lazy" alt="wize isotype" class="image-5">
-          <div class="text-block-5">Wanna talk to us? Reach for: <a href="mailto:contact@wizemice.com"><strong class="bold-text-14">contact@wizemice.com</strong></a></div>
-        </div>
-        <div class="footer-social-block-three">
-          <a href="https://www.instagram.com/wizemice/" target="_blank" class="footer-social-link-three w-inline-block"><img src="images/icons8-instagram.svg" loading="lazy" alt="insta logo" class="image-8"></a>
-          <a href="#" class="footer-social-link-three w-inline-block"><img src="images/icons8-youtube.svg" loading="lazy" alt="YT logo" class="image-9"></a>
-        </div>
-      </div>
-      <div class="footer-divider-two"></div>
-      <div class="footer-bottom">
-        <div class="footer-copyright">© 2025 WizeMice. All rights reserved</div>
-      </div>
-    </div>
+
+  <section class="wm-section wm-faq">
+    <h2>FAQ</h2>
+    <div class="wm-faq-item"><h3>What makes WizeMice different?</h3><p>Most pedals are fixed systems. WizeMice is open. You can install plugins and expand it over time.</p></div>
+    <div class="wm-faq-item"><h3>Do I need a computer to use it?</h3><p>No. It runs standalone. You can connect to a computer or phone if you want more control.</p></div>
+    <div class="wm-faq-item"><h3>What instruments does it support?</h3><p>Anything. Guitar, bass, synths, vocals, MIDI.</p></div>
+    <div class="wm-faq-item"><h3>Can I use my own plugins?</h3><p>Yes. From our store or anywhere online.</p></div>
+    <div class="wm-faq-item"><h3>What about analog tone?</h3><p>You can add analog FX cards for real analog processing.</p></div>
   </section>
+
+  <section id="waitlist" class="wm-section wm-cta">
+    <h2>Build your sound your way.</h2>
+    <a href="#waitlist-form" class="wm-btn">Join the waitlist</a>
+    <div id="waitlist-form" class="ml-embedded" data-form="mhmiBW"></div>
+  </section>
+
+  <footer class="wm-footer">
+    <a href="mailto:contact@wizemice.com">Contact</a>
+    <a href="https://www.instagram.com/wizemice/" target="_blank" rel="noopener noreferrer">Socials</a>
+    <a href="#waitlist-form">Newsletter</a>
+    <a href="#">Imprint</a>
+  </footer>
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=67a3f214f6f419803c6552fa" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>
 </body>


### PR DESCRIPTION
### Motivation
- Simplify the public site to a single, conversion-focused landing page that prioritizes the waitlist and short, bold messaging. 
- Replace the previous multi-product/product-tab layout with a minimal flow: Hero → Concept → Features → Tone3000 → Hardware → FAQ → CTA → Footer. 
- Update visuals and typography to match the provided style guidelines (dark, minimal, bold, Barlow font, prominent gradient CTA). 

### Description
- Replaced the original `index.html` with a streamlined one-page structure and updated copy that repeats the “Join the waitlist” CTAs and places the MailerLite embed in the final CTA section. 
- Reduced font loading to `Barlow` and preserved the MailerLite integration via the existing `ml('account', '1372984')` embed and `js/newsletter.js`. 
- Appended a new `wm-*` style layer to `css/wize-mice-lp.webflow.css` implementing the dark gradient background, spaced sections, Barlow typography, responsive grid/cards, and rounded gradient CTA buttons with hover glow. 
- Removed large Webflow-specific product/tab markup and interactive sections in favor of concise content blocks and responsive layout for mobile-first stacking. 

### Testing
- Ran `git diff --check` which returned clean results. 
- Verified changed files with `git status --short` to ensure only intended files were modified. 
- Attempted to capture a page screenshot with Playwright (`npx playwright screenshot ...`) but the package download failed due to the environment npm registry returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d318301c832ea7af54ce8d04e505)